### PR TITLE
Database moved to root directory

### DIFF
--- a/src/SUT/FormMain.cs
+++ b/src/SUT/FormMain.cs
@@ -98,7 +98,7 @@ namespace SUT
                     using (var db = new LiteDatabase(@"C:\temp\sut-test.db"))
     #else
                     // Open database (or create if doesn't exist)
-                    using (var db = new LiteDatabase(string.Format(@"{0}\sut.db", Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments))))
+                    using (var db = new LiteDatabase("sut.db"))
     #endif
                     {
                         // Get a collection (or create, if doesn't exist)

--- a/src/SUT/Properties/AssemblyInfo.cs
+++ b/src/SUT/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.0")]
-[assembly: AssemblyFileVersion("0.6.0")]
+[assembly: AssemblyVersion("0.6.1")]
+[assembly: AssemblyFileVersion("0.6.1")]

--- a/src/SUT/ReportingExcel.cs
+++ b/src/SUT/ReportingExcel.cs
@@ -116,7 +116,7 @@ namespace SUT
                 using (var db = new LiteDatabase(@"C:\temp\sut-test.db"))
 #else
                 // Open database (or create if doesn't exist)
-                using (var db = new LiteDatabase (string.Format (@"{0}\sut.db", Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments))))
+                using (var db = new LiteDatabase ("sut.db"))
 #endif
                 {
                     // Get a collection (or create, if doesn't exist)


### PR DESCRIPTION
The prior default location of the user's "My Documents" folder is not reliable as the OneDrive backup feature when enabled moves all files from My Documents to an equivalent under OneDrive. This leads to the application creating a new sut.db database file in My Documents which is then moved arbitrarily by OneDrive causing fragmentation of work units across multiple database files. This change stores the database in the root directory where the binaries are stored.